### PR TITLE
Add support for using winrm with windows guest vagrant boxes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,6 +64,11 @@ some.property=${env.VARIABLE_NAME}
 
 {my-host-label}.vagrantIp - IP address of the Vagrant host
 
+{my-host-label}.vagrantVm - Name of the Vagrant host
+
+{my-host-label}.vagrantOs - OS type of the Vagrant host (WINDOWS, UNIX)
+
+{my-host-label}.vagrantSnapshotExpirationCmd - Command used to expire the snapshot image of the Vagrant host
 
 ##### VirtualBox host properties
 {my-host-label}.vboxUuid - UUID of the virtual machine

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'com.google.guava:guava:10.0.1'
     compile 'net.schmizz:sshj:0.7.0'
-    compile 'com.xebialabs.overthere:overthere:2.2.0'
+    compile 'com.xebialabs.overthere:overthere:2.4.1'
     compile 'org.slf4j:slf4j-api:1.7.2'
     compile 'org.freemarker:freemarker:2.3.19'
 

--- a/src/main/java/com/xebialabs/overcast/host/CachedVagrantCloudHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/CachedVagrantCloudHost.java
@@ -66,7 +66,7 @@ class CachedVagrantCloudHost extends VagrantCloudHost {
         if (expirationTag.equals(virtualboxDriver.getExtraData(vagrantVm, EXPIRATION_TAG_PROPERTY_KEY))) {
             logger.info("Cache hit. Loading the latest snapshot of the VM");
             virtualboxDriver.loadLatestSnapshot(vagrantVm);
-            logger.info("Waiting for the VM to become accessible via SSH");
+            logger.info("Waiting for the VM to become accessible...");
 
             boolean connected = false;
             int currentAttempt = 1;


### PR DESCRIPTION
By defining a .vagrantOs=WINDOWS in the overcast.properties, winrm will be
used instead of ssh to "ping" the box while booting up
