### PR TITLE
Add possibility to specify custom overcast.conf file path

### DIFF
--- a/src/main/java/com/xebialabs/overcast/PropertiesLoader.java
+++ b/src/main/java/com/xebialabs/overcast/PropertiesLoader.java
@@ -31,6 +31,7 @@ public class PropertiesLoader {
 
     public static final String OVERCAST_CONF_FILE = "overcast.conf";
     public static final String OVERCAST_USER_DIR = ".overcast";
+    public static final String OVERCAST_CONF_FILE_PROPERTY = "overcast.conf.file";
 
     private static String getUserOvercastConfPath() {
         return new File(new File(System.getProperty("user.home"), OVERCAST_USER_DIR), OVERCAST_CONF_FILE).getAbsolutePath();
@@ -40,7 +41,9 @@ public class PropertiesLoader {
         return ConfigFactory.systemProperties()
             .withFallback(loadOvercastConfigFromFile(getUserOvercastConfPath()))
             .withFallback(loadOvercastConfigFromFile(OVERCAST_CONF_FILE))
-            .withFallback(loadOvercastConfigFromClasspath(OVERCAST_CONF_FILE)).resolve();
+            .withFallback(loadOvercastConfigFromFile(System.getProperty(OVERCAST_CONF_FILE_PROPERTY)))
+            .withFallback(loadOvercastConfigFromClasspath(OVERCAST_CONF_FILE))
+            .resolve();
     }
 
     /** Load {@link Config} from 'file' but do not resolve it. */
@@ -59,6 +62,11 @@ public class PropertiesLoader {
 
     /** Load {@link Config} from 'file' but do not resolve it. */
     static Config loadOvercastConfigFromFile(String file) {
+
+        if (file == null) {
+            return ConfigFactory.empty();
+        }
+
         File f = new File(file);
         if (!f.exists()) {
             logger.warn("File {} not found.", f.getAbsolutePath());

--- a/src/test/java/com/xebialabs/overcast/OvercastPropertiesTest.java
+++ b/src/test/java/com/xebialabs/overcast/OvercastPropertiesTest.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,6 +38,11 @@ public class OvercastPropertiesTest {
     @Before
     public void setup() {
         System.setProperty("user.home", new File("src/test/resources/fake-home").getAbsolutePath());
+    }
+
+    @After
+    public void teardown() {
+        System.clearProperty("overcast.conf.file");
     }
 
     @Test
@@ -91,6 +98,37 @@ public class OvercastPropertiesTest {
         OvercastProperties.reloadOvercastProperties();
 
         assertThat(OvercastProperties.getOvercastProperty("precedenceTestValue"), is("valueFromHome"));
+    }
+
+    @Test
+    public void testPropertyHasPrecedenceOverClasspath() throws IOException {
+
+        System.setProperty("user.home", new File("src/test/resources/dir-without-conf").getAbsolutePath());
+        System.clearProperty("precedenceTestValue");
+        System.setProperty("overcast.conf.file", "src/test/resources/property-path/overcast.conf");
+        
+        File cfg = new File("overcast.conf");
+        File bkp = new File("backup.conf");
+        
+        try {
+            FileUtils.moveFile(cfg, bkp);
+            OvercastProperties.reloadOvercastProperties();
+            assertThat(OvercastProperties.getOvercastProperty("precedenceTestValue"), is("valueFromProperty"));
+        } finally {
+            FileUtils.moveFile(bkp, cfg);
+        }
+    }
+
+    @Test
+    public void testWorkDirHasPrecedenceOverProperty() throws IOException {
+
+        System.setProperty("user.home", new File("src/test/resources/dir-without-conf").getAbsolutePath());
+        System.clearProperty("precedenceTestValue");
+        System.setProperty("overcast.conf.file", "src/test/resources/property-path/overcast.conf");
+        
+        OvercastProperties.reloadOvercastProperties();
+
+        assertThat(OvercastProperties.getOvercastProperty("precedenceTestValue"), is("valueFromWork"));
     }
 
     @Test

--- a/src/test/java/com/xebialabs/overcast/PropertiesLoaderTest.java
+++ b/src/test/java/com/xebialabs/overcast/PropertiesLoaderTest.java
@@ -24,6 +24,8 @@ import com.typesafe.config.Config;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 public class PropertiesLoaderTest {
 
@@ -43,6 +45,13 @@ public class PropertiesLoaderTest {
     public void shouldLoadPropertiesFromPath() throws IOException {
         Config cfg = PropertiesLoader.loadOvercastConfigFromFile("src/test/resources/overcast.conf").resolve();
         assertThat(cfg.getString("unittestHost.someProp"), is("someValue"));
+    }
+
+    @Test
+    public void shouldLoadEmptyPropertiesFromNull() throws IOException {
+        Config cfg = PropertiesLoader.loadOvercastConfigFromFile(null).resolve();
+        assertNotNull(cfg);
+        assertTrue(cfg.isEmpty());
     }
 
     @Test

--- a/src/test/resources/property-path/overcast.conf
+++ b/src/test/resources/property-path/overcast.conf
@@ -1,0 +1,1 @@
+precedenceTestValue=valueFromProperty


### PR DESCRIPTION
Hello @xebialabs team!

First at all I would like to thank you for this wonderful masterpiece in form of Overcast. It's really helping me manage my integration tests, however, I found it impossible to coexists with my own project due to many conflicting dependencies (mostly Jackson), so I created dedicated Maven plugin to do the dirty job for me. The plugin can be found here:

https://github.com/sarxos/overcast-maven-plugin

Ok, now to the core of the problem. Overcast accepts ```overcast.con``` file from few locations only, those are:
* User's home directory (this is unacceptable in my case),
* Application's work directory,
* Classpath root.

This limitation causes huge pain when one have multimodule project where configuration can be accepted from root (parent POM) directory only. It's painful because one cannot build submodule (it does not contain configuration file) without building parent (and thus all the other modules). This pull request is to address this issue.

### Solution

I added possibility to specify ```overcast.conf``` file location by ```-D``` option (via Java properties).
