### PR TITLE
Flag to remove volume along with container

### DIFF
--- a/src/main/java/com/xebialabs/overcast/host/CloudHostFactory.java
+++ b/src/main/java/com/xebialabs/overcast/host/CloudHostFactory.java
@@ -144,6 +144,7 @@ public class CloudHostFactory {
         dockerHost.setCommand(getOvercastListProperty(label + Config.DOCKER_COMMAND_SUFFIX));
         dockerHost.setExposeAllPorts(getOvercastBooleanProperty(label + Config.DOCKER_EXPOSE_ALL_PORTS_SUFFIX));
         dockerHost.setRemove(getOvercastBooleanProperty(label + Config.DOCKER_REMOVE_SUFFIX));
+        dockerHost.setRemoveVolume(getOvercastBooleanProperty(label + Config.DOCKER_REMOVE_VOLUME_SUFFIX));
         dockerHost.setEnv(getOvercastListProperty(label + Config.DOCKER_ENV_SUFFIX));
         dockerHost.setExposedPorts(newHashSet(getOvercastListProperty(label + Config.DOCKER_EXPOSED_PORTS_SUFFIX)));
 

--- a/src/main/java/com/xebialabs/overcast/host/DockerHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/DockerHost.java
@@ -34,6 +34,7 @@ public class DockerHost implements CloudHost {
     private URI uri;
     private String name;
     private boolean remove;
+    private boolean removeVolume;
     private List<String> env;
     private Set<String> exposedPorts;
 
@@ -110,6 +111,14 @@ public class DockerHost implements CloudHost {
 
     public void setRemove(final boolean remove) {
         this.remove = remove;
+    }
+
+    public boolean isRemoveVolume() {
+        return removeVolume;
+    }
+
+    public void setRemoveVolume(final boolean removeVolume) {
+        this.removeVolume = removeVolume;
     }
 
     public List<String> getEnv() {

--- a/src/main/java/com/xebialabs/overcast/support/docker/Config.java
+++ b/src/main/java/com/xebialabs/overcast/support/docker/Config.java
@@ -21,6 +21,7 @@ public class Config {
     public static final String DOCKER_NAME_SUFFIX = ".name";
     public static final String DOCKER_COMMAND_SUFFIX = ".command";
     public static final String DOCKER_REMOVE_SUFFIX = ".remove";
+    public static final String DOCKER_REMOVE_VOLUME_SUFFIX = ".removeVolume";
     public static final String DOCKER_ENV_SUFFIX = ".env";
     public static final String DOCKER_EXPOSED_PORTS_SUFFIX = ".exposedPorts";
 

--- a/src/main/java/com/xebialabs/overcast/support/docker/DockerDriver.java
+++ b/src/main/java/com/xebialabs/overcast/support/docker/DockerDriver.java
@@ -96,7 +96,7 @@ public class DockerDriver {
         try {
             dockerClient.killContainer(containerId);
             if(dockerHost.isRemove()) {
-                dockerClient.removeContainer(containerId);
+                dockerClient.removeContainer(containerId, dockerHost.isRemoveVolume());
             }
         } catch (Exception e) {
             logger.error("Error while tearing down docker host: ", e);


### PR DESCRIPTION
Hello @xebialabs,

Let me describe the problem first.

We are doing integration tests with Overcast using Docker containers and they works really great! However, after the time, we realized that Overcast does not remove Docker volumes on teardown and, moreover, there is no way to configure such behaviour.

We found this issue rather by accident when our Jenkins CI failed due to no space left on a device which has been exhausted by hundreds of old volumes :(

To w/a this problem we were using [docker-cleanup-volumes](https://github.com/chadoe/docker-cleanup-volumes) script by [Martin van Beurden](https://github.com/chadoe), but this is still just a w/a and not a permanent solution.

Thus, due to above, this pull request is to address the root cause of problem described. This small enhancement gives user possibility to specify flag to decide whether volume should be removed when container is deleted by adding ```removeVolume``` property in Overcast configuration file. The default value for this flag is  ```false``` so the change is backward-compatible with older releases.

Example config (vide ```removeVolume=true``` at the end):

```plain
elmRedis {
	dockerHost="unix:///var/run/docker.sock"
	dockerImage="redis:2.8"
	exposeAllPorts=true
	remove=true
	removeVolume=true
}
```

We are doing IT with this fix for some time now and old Docker volumes does not spawn any more, did not observe any side effects as well, and therefore decide to share this with you.