### PR TITLE
Adding HTTPS support for Docker managed hosts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     compile 'org.jdom:jdom2:2.0.5'
     compile "org.apache.httpcomponents:httpcore:${apacheHttpVersion}"
     compile "org.apache.httpcomponents:httpclient:${apacheHttpVersion}"
-    compile "com.spotify:docker-client:2.4.2"
+    compile "com.spotify:docker-client:3.1.3"
     compile "com.fasterxml.jackson.core:jackson-annotations:2.2.3"  // appease annotation warnings
     compile "javax.ws.rs:jsr311-api:1.1.1"                          // appease annotation warnings
 

--- a/src/main/java/com/xebialabs/overcast/host/CloudHostFactory.java
+++ b/src/main/java/com/xebialabs/overcast/host/CloudHostFactory.java
@@ -15,6 +15,7 @@
  */
 package com.xebialabs.overcast.host;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import org.libvirt.Connect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
 import com.xebialabs.overcast.OvercastProperties;
 import com.xebialabs.overcast.command.Command;
 import com.xebialabs.overcast.command.CommandProcessor;
@@ -138,7 +140,8 @@ public class CloudHostFactory {
 
         String image = getOvercastProperty(label + Config.DOCKER_IMAGE_SUFFIX, Config.DOCKER_DEFAULT_IMAGE);
         String dockerHostName = getOvercastProperty(label + Config.DOCKER_HOST_SUFFIX, Config.DOCKER_DEFAULT_HOST);
-        DockerHost dockerHost = new DockerHost(image, dockerHostName);
+        String certicates = getOvercastProperty(label + Config.DOCKER_CERTIFICATES, null);
+        DockerHost dockerHost = new DockerHost(image, dockerHostName, Strings.isNullOrEmpty(certicates) ? null : new File(certicates).toPath());
 
         dockerHost.setName(getOvercastProperty(label + Config.DOCKER_NAME_SUFFIX));
         dockerHost.setCommand(getOvercastListProperty(label + Config.DOCKER_COMMAND_SUFFIX));

--- a/src/main/java/com/xebialabs/overcast/support/docker/Config.java
+++ b/src/main/java/com/xebialabs/overcast/support/docker/Config.java
@@ -16,6 +16,7 @@
 package com.xebialabs.overcast.support.docker;
 
 public class Config {
+    public static final String DOCKER_CERTIFICATES = ".certificates";
     public static final String DOCKER_HOST_SUFFIX = ".dockerHost";
     public static final String DOCKER_IMAGE_SUFFIX = ".dockerImage";
     public static final String DOCKER_NAME_SUFFIX = ".name";


### PR DESCRIPTION
Hey guys!

First of all, thanks for your awesome library. We started to used it for integration testing and missed couple of features. One of those is HTTPS support for Docker agent communication. Recent releases of Spotify Docker Clent do support HTTPS and it is quite easy to integrate.

Primarily, it becomes very useful for developers on MacOS where Docker is not supported natively and requires boot2docker wrapper (which by default uses HTTPS).

This PR adds an optional property to overcast.conf called **certficates**, which could be used like that:
```
container-name {
    certificates = "/etc/boot2docker/certs"
    dockerHost = "https://boot2docker-ip:2576",
    dockerImage = "..."
}
```

This property is picked for HTTPS connections only and, if not provided for HTTPS, throws an exception while creating DockerHost through DockerDriver. It seems to work pretty well while no regressions have been observed during the Spotify Docker Client upgrade.

Thank you.

Best Regards,
    Andriy Redko