### PR TITLE
Fixed issue which caused provisioning of domain each time because of …

### DIFF
--- a/src/main/java/com/xebialabs/overcast/host/CachedLibvirtHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/CachedLibvirtHost.java
@@ -85,17 +85,17 @@ public class CachedLibvirtHost extends LibvirtHost {
         int startTimeout, int bootDelay, int provisionStartTimeout, int provisionedbootDelay,
         List<Filesystem> filesystemMappings, List<String> copySpec) {
         super(libvirt, baseDomainName, ipLookupStrategy, networkName, startTimeout, bootDelay, filesystemMappings);
-        this.provisionUrl = checkNotNullOrEmptyAndTrim(provisionUrl, "provisionUrl");
-        this.provisionCmd = checkNotNullOrEmptyAndTrim(provisionCmd, "provisionCmd");
+        this.provisionUrl = checkNotNullTrimAndNotEmpty(provisionUrl, "provisionUrl");
+        this.provisionCmd = checkNotNullTrimAndNotEmpty(provisionCmd, "provisionCmd");
         this.cacheExpirationUrl = cacheExpirationUrl;
-        this.cacheExpirationCmd = checkNotNullOrEmptyAndTrim(cacheExpirationCmd, "cacheExpirationCmd");
+        this.cacheExpirationCmd = checkNotNullTrimAndNotEmpty(cacheExpirationCmd, "cacheExpirationCmd");
         this.provisionedbootDelay = provisionedbootDelay;
         this.provisionStartTimeout = provisionStartTimeout;
         this.cmdProcessor = cmdProcessor;
         this.copySpec = copySpec;
     }
 
-    private String checkNotNullOrEmptyAndTrim(String arg, String argName) {
+    private String checkNotNullTrimAndNotEmpty(String arg, String argName) {
         checkArgument(arg != null , "%s cannot be null", argName);
         arg = arg.trim();
         checkArgument(!arg.isEmpty(), "%s cannot be empty", argName);

--- a/src/main/java/com/xebialabs/overcast/host/CachedLibvirtHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/CachedLibvirtHost.java
@@ -86,7 +86,7 @@ public class CachedLibvirtHost extends LibvirtHost {
         List<Filesystem> filesystemMappings, List<String> copySpec) {
         super(libvirt, baseDomainName, ipLookupStrategy, networkName, startTimeout, bootDelay, filesystemMappings);
         this.provisionUrl = checkNotNullOrEmpty(provisionUrl, "provisionUrl");
-        this.provisionCmd = checkNotNullOrEmpty(provisionCmd, "provisionCmd");
+        this.provisionCmd = checkNotNullOrEmpty(provisionCmd, "provisionCmd").trim();
         this.cacheExpirationUrl = cacheExpirationUrl;
         this.cacheExpirationCmd = checkNotNullOrEmpty(cacheExpirationCmd, "cacheExpirationCmd");
         this.provisionedbootDelay = provisionedbootDelay;

--- a/src/main/java/com/xebialabs/overcast/host/CachedLibvirtHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/CachedLibvirtHost.java
@@ -85,18 +85,20 @@ public class CachedLibvirtHost extends LibvirtHost {
         int startTimeout, int bootDelay, int provisionStartTimeout, int provisionedbootDelay,
         List<Filesystem> filesystemMappings, List<String> copySpec) {
         super(libvirt, baseDomainName, ipLookupStrategy, networkName, startTimeout, bootDelay, filesystemMappings);
-        this.provisionUrl = checkNotNullOrEmpty(provisionUrl, "provisionUrl");
-        this.provisionCmd = checkNotNullOrEmpty(provisionCmd, "provisionCmd").trim();
+        this.provisionUrl = checkNotNullOrEmptyAndTrim(provisionUrl, "provisionUrl");
+        this.provisionCmd = checkNotNullOrEmptyAndTrim(provisionCmd, "provisionCmd");
         this.cacheExpirationUrl = cacheExpirationUrl;
-        this.cacheExpirationCmd = checkNotNullOrEmpty(cacheExpirationCmd, "cacheExpirationCmd");
+        this.cacheExpirationCmd = checkNotNullOrEmptyAndTrim(cacheExpirationCmd, "cacheExpirationCmd");
         this.provisionedbootDelay = provisionedbootDelay;
         this.provisionStartTimeout = provisionStartTimeout;
         this.cmdProcessor = cmdProcessor;
         this.copySpec = copySpec;
     }
 
-    private String checkNotNullOrEmpty(String arg, String argName) {
-        checkArgument(arg != null && !arg.isEmpty(), "%s cannot be null or empty", argName);
+    private String checkNotNullOrEmptyAndTrim(String arg, String argName) {
+        checkArgument(arg != null , "%s cannot be null", argName);
+        arg = arg.trim();
+        checkArgument(!arg.isEmpty(), "%s cannot be empty", argName);
         return arg;
     }
 


### PR DESCRIPTION
Fixed issue which caused provisioning of domain each time because of provisioning command mismatch between provision command from overcast.conf and one returned by existing domain in kvm, the comparison failure is caused by trailing blank space on provision command in overcast.conf. Provisioning command on kvm is returned without a training space even if it exists on original command. This causes a comparison failure and provisioning of new image each time.