### PR TITLE
Upgraded to latest docker-client release 5.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compile 'org.jdom:jdom2:2.0.5'
 
     // docker-client and friends
-    compile "com.spotify:docker-client:3.1.3"
+    compile "com.spotify:docker-client:5.0.2"
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.2.3'  // appease annotation warnings in docker-client
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'                     // appease annotation warnings in docker-client
 

--- a/itest/overcast-docker-itest/src/test/java/com/xebialabs/overcast/host/DockerHostItest.java
+++ b/itest/overcast-docker-itest/src/test/java/com/xebialabs/overcast/host/DockerHostItest.java
@@ -15,23 +15,9 @@
  */
 package com.xebialabs.overcast.host;
 
-import java.util.List;
-import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.spotify.docker.client.ContainerNotFoundException;
-import com.spotify.docker.client.DefaultDockerClient;
-import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.DockerException;
-import com.spotify.docker.client.messages.ContainerInfo;
-
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -40,6 +26,22 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.ContainerNotFoundException;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.ContainerInfo;
 
 public class DockerHostItest {
     // port range can be system specific e.g.
@@ -52,18 +54,19 @@ public class DockerHostItest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void shouldRunMinimalConfig() throws DockerException, InterruptedException {
+    public void shouldRunMinimalConfig() throws DockerException, DockerCertificateException, InterruptedException {
         DockerHost itestHost = (DockerHost) CloudHostFactory.getCloudHost("dockerMinimalConfig");
         assertThat(itestHost, notNullValue());
+        assertThat(itestHost.getUri(), nullValue());
 
-        DockerClient dockerClient = new DefaultDockerClient(itestHost.getUri());
+        DockerClient dockerClient = DefaultDockerClient.fromEnv().build();
         String containerId = null;
 
         try {
             itestHost.setup();
             assertThat(itestHost.getHostName(), equalTo("localhost"));
 
-            dockerClient = new DefaultDockerClient(itestHost.getUri());
+            dockerClient = DefaultDockerClient.fromEnv().build();
             containerId = itestHost.getDockerDriver().getContainerId();
             dockerClient.inspectContainer(containerId);
         } finally {

--- a/src/main/java/com/xebialabs/overcast/host/CloudHostFactory.java
+++ b/src/main/java/com/xebialabs/overcast/host/CloudHostFactory.java
@@ -139,7 +139,7 @@ public class CloudHostFactory {
     private static CloudHost createDockerHost(String label, String imageName) {
 
         String image = getOvercastProperty(label + Config.DOCKER_IMAGE_SUFFIX, Config.DOCKER_DEFAULT_IMAGE);
-        String dockerHostName = getOvercastProperty(label + Config.DOCKER_HOST_SUFFIX, Config.DOCKER_DEFAULT_HOST);
+        String dockerHostName = getOvercastProperty(label + Config.DOCKER_HOST_SUFFIX);
         String certicates = getOvercastProperty(label + Config.DOCKER_CERTIFICATES, null);
         DockerHost dockerHost = new DockerHost(image, dockerHostName, Strings.isNullOrEmpty(certicates) ? null : new File(certicates).toPath());
 

--- a/src/main/java/com/xebialabs/overcast/host/DockerHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/DockerHost.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
 import com.xebialabs.overcast.support.docker.DockerDriver;
 
 public class DockerHost implements CloudHost {
@@ -47,20 +48,25 @@ public class DockerHost implements CloudHost {
     }
 
     public DockerHost(String image, String dockerHostName, Path certificatesPath) {
-        try {
-            this.uri = new URI(dockerHostName);
-        } catch (URISyntaxException e) {
-            logger.error("could not parse host name", e);
-            throw new IllegalArgumentException("could not parse host name");
-        }
-        this.image = image;
-        
-        if (uri.getScheme().endsWith("https")) {
-            if (certificatesPath == null) {
-                throw new IllegalArgumentException("certificates are required for secured connections");
-            }
-            
-            dockerDriver = new DockerDriver(this, certificatesPath);
+    	this.image = image;
+    	
+        if (!Strings.isNullOrEmpty(dockerHostName)) {
+            try {
+	            this.uri = new URI(dockerHostName);
+	        } catch (URISyntaxException e) {
+	            logger.error("could not parse host name", e);
+	            throw new IllegalArgumentException("could not parse host name");
+	        }
+	        
+	        if (uri.getScheme().endsWith("https")) {
+	            if (certificatesPath == null) {
+	                throw new IllegalArgumentException("certificates are required for secured connections");
+	            }
+	            
+	            dockerDriver = new DockerDriver(this, certificatesPath);
+	        } else {
+	            dockerDriver = new DockerDriver(this);
+	        }
         } else {
             dockerDriver = new DockerDriver(this);
         }
@@ -83,7 +89,7 @@ public class DockerHost implements CloudHost {
 
     @Override
     public String getHostName() {
-        return uri.getHost();
+        return dockerDriver.getHost();
     }
 
     public String getImage() {

--- a/src/main/java/com/xebialabs/overcast/host/Ec2CloudHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/Ec2CloudHost.java
@@ -16,6 +16,7 @@
 package com.xebialabs.overcast.host;
 
 import java.util.Date;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.amazonaws.auth.BasicAWSCredentials;

--- a/src/main/java/com/xebialabs/overcast/host/ExistingCloudHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/ExistingCloudHost.java
@@ -44,6 +44,5 @@ class ExistingCloudHost implements CloudHost {
     public int getPort(int port) {
         return port;
     }
-
 }
 

--- a/src/main/java/com/xebialabs/overcast/host/VagrantCloudHost.java
+++ b/src/main/java/com/xebialabs/overcast/host/VagrantCloudHost.java
@@ -71,5 +71,4 @@ public class VagrantCloudHost implements CloudHost {
     public int getPort(int port) {
         return port;
     }
-
 }

--- a/src/main/java/com/xebialabs/overcast/support/docker/Config.java
+++ b/src/main/java/com/xebialabs/overcast/support/docker/Config.java
@@ -28,6 +28,5 @@ public class Config {
 
     public static final String DOCKER_EXPOSE_ALL_PORTS_SUFFIX = ".exposeAllPorts";
     public static final String DOCKER_TTY_SUFFIX = ".tty";
-    public static final String DOCKER_DEFAULT_HOST = "http://localhost:2375";
     public static final String DOCKER_DEFAULT_IMAGE = "busybox";
 }

--- a/src/main/java/com/xebialabs/overcast/support/docker/ProcessHandlerLogger.java
+++ b/src/main/java/com/xebialabs/overcast/support/docker/ProcessHandlerLogger.java
@@ -17,8 +17,9 @@ package com.xebialabs.overcast.support.docker;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.spotify.docker.client.DockerException;
+
 import com.spotify.docker.client.ProgressHandler;
+import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.ProgressMessage;
 
 public class ProcessHandlerLogger implements ProgressHandler {

--- a/src/main/java/com/xebialabs/overcast/support/vagrant/VagrantDriver.java
+++ b/src/main/java/com/xebialabs/overcast/support/vagrant/VagrantDriver.java
@@ -32,7 +32,7 @@ public class VagrantDriver {
 
     /**
      * Executes vagrant command which means that arguments passed here will be prepended with "vagrant"
-     * @param vagrantCommand arguments for <i><vagrant</i> command
+     * @param vagrantCommand arguments for <i>vagrant</i> command
      * @return vagrant response object
      */
     public CommandResponse doVagrant(String vagrantVm, final String... vagrantCommand) {


### PR DESCRIPTION
Hi Ric,

The Spotify's **docker-client** went though a couple of major releases and is in much better shape right now. This PR bumps up the **docker-client** version to **5.0.2**. Not only that, now Overcast can use the latest environment-based discovery (DOCKER_HOST, etc.) offered by  **docker-client**.  

With that, here is the summary of the changes:
- Dependency on **docker-client 5.0.2**
- The **dockerHost** configuration property became optional. If it is not provided, Overcast uses environment-based discovery. It works out of the box everywhere I had a chance to test it (MacOS with boot2docker, Docker for MacOS, CentOS + Docker, ...) without single configuration change required, really awesome stuff.

I would love to hear your opinion on this PR. Those changes proved to be very useful for developing robust, easy to distribute test cases based on **Overcast**.

Thanks.

Best Regards,
    Andriy Redko
